### PR TITLE
Remove order bys to improve performance

### DIFF
--- a/models/stripe__balance_transactions.sql
+++ b/models/stripe__balance_transactions.sql
@@ -118,5 +118,3 @@ left join refund
     on refund.balance_transaction_id = balance_transaction.balance_transaction_id
 left join charge as refund_charge 
     on refund.charge_id = refund_charge.charge_id
-    
-order by created_at desc

--- a/models/stripe__daily_overview.sql
+++ b/models/stripe__daily_overview.sql
@@ -85,5 +85,3 @@ from daily_balance_transactions
 
 left join daily_failed_charges 
       on daily_balance_transactions.date = daily_failed_charges.date
-      
-order by 1 desc

--- a/models/stripe__invoice_line_items.sql
+++ b/models/stripe__invoice_line_items.sql
@@ -93,5 +93,3 @@ left join plan
 
 left join customer 
     on invoice.customer_id = customer.customer_id
-
-order by invoice.created_at desc

--- a/models/stripe__monthly_overview.sql
+++ b/models/stripe__monthly_overview.sql
@@ -23,4 +23,3 @@ select
     sum(total_failed_charge_amount) as total_failed_charge_amount
 from daily_overview
 group by 1
-order by 1 desc

--- a/models/stripe__quarterly_overview.sql
+++ b/models/stripe__quarterly_overview.sql
@@ -23,4 +23,3 @@ select
     sum(total_failed_charge_amount) as total_failed_charge_amount
 from daily_overview
 group by 1
-order by 1 desc

--- a/models/stripe__subscription_details.sql
+++ b/models/stripe__subscription_details.sql
@@ -89,4 +89,3 @@ left join grouped_by_subscription
   on subscription.subscription_id = grouped_by_subscription.subscription_id
 left join customer 
   on subscription.customer_id = customer.customer_id
-order by subscription.created_at desc

--- a/models/stripe__weekly_overview.sql
+++ b/models/stripe__weekly_overview.sql
@@ -23,4 +23,3 @@ select
     sum(total_failed_charge_amount) as total_failed_charge_amount
 from daily_overview
 group by 1
-order by 1 desc


### PR DESCRIPTION
Order not retained when storing tables so the order bys aren't adding anything while being an expensive operation.